### PR TITLE
Remove buildkite configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,11 @@
   "version": "0.0.5",
   "renovate-config": {
     "default": {
-      "extends": ["config:base"],
+      "extends": [
+        "config:base"
+      ],
       "automerge": true,
       "automergeType": "pr",
-      "buildkite": {
-        "enabled": true
-      },
       "pinVersions": false,
       "prConcurrentLimit": 1
     }


### PR DESCRIPTION
This option is now enabled by default so we no longer need to explicitly turn it on.